### PR TITLE
"神戸大学プログラミングサークル"の文字列を追加

### DIFF
--- a/makehomepage/layouts/default.vue
+++ b/makehomepage/layouts/default.vue
@@ -63,7 +63,7 @@
             Pablo
           </h1>
           <p class="hero__text">
-            協調を通じて成長する場所
+            神戸大学プログラミングサークル
           </p>
         </v-col>
       </v-row>


### PR DESCRIPTION
"協調を通じて成長する場所"を置き換えました．